### PR TITLE
Add README with badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Shaft
+
+[<img alt="github" src="https://img.shields.io/badge/github-lokyhark/sparse-2e2459?style=for-the-badge&logo=github">](https://github.com/lokyhark/sparse)
+[<img alt="crates.io" src="https://img.shields.io/crates/v/sparse.svg?style=for-the-badge&color=ffc832&logo=rust">](https://crates.io/crates/sparse)
+[<img alt="docs.rs" src="https://img.shields.io/badge/docs.rs-sparse-a72145?style=for-the-badge&logo=docs.rs">](https://docs.rs/sparse)
+[<img alt="github actions" src="https://img.shields.io/github/actions/workflow/status/lokyhark/sparse/default.yaml?branch=default&color=0b7261&label=Actions&logo=GitHub%20Actions&logoColor=white&style=for-the-badge">](https://github.com/lokyhark/sparse/actions/workflows/default.yaml)


### PR DESCRIPTION
This pull request adds project badges to the `README.md` file to provide quick links and status indicators for the repository, crates.io, documentation, and CI actions.

Close #8 